### PR TITLE
Ability to Show No Data Message

### DIFF
--- a/src/components/table.component.ts
+++ b/src/components/table.component.ts
@@ -62,6 +62,7 @@ export class DataTable implements DataTableParams, OnInit {
     @Input() selectOnRowClick = false;
     @Input() autoReload = true;
     @Input() showReloading = false;
+    @Input() noDataMessage: string;
 
     // UI state without input:
 

--- a/src/components/table.template.ts
+++ b/src/components/table.template.ts
@@ -32,6 +32,11 @@ export const TABLE_TEMPLATE = `
             <tbody *ngFor="let item of items; let index=index" class="data-table-row-wrapper"
                    dataTableRow #row [item]="item" [index]="index" (selectedChange)="onRowSelectChanged(row)">
             </tbody>
+            <tbody *ngIf="itemCount === 0 && noDataMessage">
+                <tr>
+                    <td [attr.colspan]="columnCount">{{ noDataMessage }}</td>
+                </tr>
+            </tbody>
             <tbody class="substitute-rows" *ngIf="pagination && substituteRows">
                 <tr *ngFor="let item of substituteItems, let index = index"
                     [class.row-odd]="(index + items.length) % 2 === 0"


### PR DESCRIPTION
Added a new tbody tag where a message can be displayed if there is no data to display in the table. The column spans the full length of the table. It only displays when the itemCount is 0 and the user passed a noDataMessage to the component.

There is a new Input to the table called noDataMessage.